### PR TITLE
Add nearby routes discovery

### DIFF
--- a/src/app/api/nearby-routes/route.ts
+++ b/src/app/api/nearby-routes/route.ts
@@ -1,0 +1,155 @@
+/**
+ * API Route: Nearby Routes Discovery
+ *
+ * Fetches SEPTA routes running within a specified distance of a point
+ * using ArcGIS spatial queries. Queries both bus/trolley and regional rail
+ * route geometries in parallel.
+ *
+ * @endpoint GET /api/nearby-routes?lat={latitude}&lng={longitude}&distance={miles}
+ * @param lat - Latitude of the center point
+ * @param lng - Longitude of the center point
+ * @param distance - Search radius in miles (default: 0.25)
+ * @returns GeoJSON FeatureCollection with LineAbbr and LineName properties
+ *
+ * @example
+ * GET /api/nearby-routes?lat=39.9526&lng=-75.1652&distance=0.25
+ * Returns all routes within 0.25 miles of Philadelphia City Hall
+ */
+
+import { NextRequest } from 'next/server';
+import { createErrorResponse, createSuccessResponse, handleApiError } from '@/lib/api/apiResponse';
+import { ARCGIS_ENDPOINTS } from '@/config/api.config';
+import { SEPTA_TO_OUR_LINE_NAME_MAPPING } from '@/constants/routes';
+import type {
+  ArcGISFeatureCollection,
+  ArcGISRailAttributes,
+  ArcGISRouteAttributes,
+  ArcGISFeature,
+} from '@/types/septa-api.types';
+
+/**
+ * Transforms bus/trolley features to standardized format
+ */
+function transformTransitFeatures(
+  features: ArcGISFeature<ArcGISRouteAttributes>[]
+): ArcGISFeature<{ LineAbbr: string; LineName: string }>[] {
+  return features.map((feature) => ({
+    type: 'Feature' as const,
+    properties: {
+      LineAbbr: feature.properties?.LineAbbr || '',
+      LineName: feature.properties?.LineName || '',
+    },
+    geometry: feature.geometry,
+  }));
+}
+
+/**
+ * Transforms rail features from SEPTA's naming to our app's naming
+ */
+function transformRailFeatures(
+  features: ArcGISFeature<ArcGISRailAttributes>[]
+): ArcGISFeature<{ LineAbbr: string; LineName: string }>[] {
+  return features.map((feature) => {
+    const septaRouteName = feature.properties?.Route_Name || '';
+    const ourRouteName =
+      SEPTA_TO_OUR_LINE_NAME_MAPPING[septaRouteName] || septaRouteName;
+
+    return {
+      type: 'Feature' as const,
+      properties: {
+        LineAbbr: ourRouteName,
+        LineName: ourRouteName,
+      },
+      geometry: feature.geometry,
+    };
+  });
+}
+
+/**
+ * Queries ArcGIS Feature Server for routes near a point
+ */
+async function queryNearbyRoutes(
+  endpoint: string,
+  lat: number,
+  lng: number,
+  distance: number
+): Promise<ArcGISFeatureCollection> {
+  const queryUrl = new URL(endpoint);
+
+  // Spatial query parameters for ArcGIS
+  queryUrl.searchParams.set('geometry', `${lng},${lat}`);
+  queryUrl.searchParams.set('geometryType', 'esriGeometryPoint');
+  queryUrl.searchParams.set('spatialRel', 'esriSpatialRelIntersects');
+  queryUrl.searchParams.set('distance', distance.toString());
+  queryUrl.searchParams.set('units', 'esriSRUnit_StatuteMile');
+  queryUrl.searchParams.set('returnGeometry', 'true');
+  queryUrl.searchParams.set('outFields', '*');
+  queryUrl.searchParams.set('f', 'geojson');
+
+  const response = await fetch(queryUrl.toString());
+
+  if (!response.ok) {
+    throw new Error(`ArcGIS API responded with status: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+
+  // Extract and validate parameters
+  const latParam = searchParams.get('lat');
+  const lngParam = searchParams.get('lng');
+  const distanceParam = searchParams.get('distance');
+
+  if (!latParam || !lngParam) {
+    return createErrorResponse('lat and lng parameters are required', 400);
+  }
+
+  const lat = parseFloat(latParam);
+  const lng = parseFloat(lngParam);
+  const distance = distanceParam ? parseFloat(distanceParam) : 0.25;
+
+  // Validate numeric values
+  if (isNaN(lat) || isNaN(lng) || isNaN(distance)) {
+    return createErrorResponse('Invalid numeric parameters', 400);
+  }
+
+  // Validate reasonable bounds
+  if (lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+    return createErrorResponse('Coordinates out of valid range', 400);
+  }
+
+  if (distance <= 0 || distance > 5) {
+    return createErrorResponse('Distance must be between 0 and 5 miles', 400);
+  }
+
+  try {
+    // Query both bus/trolley and rail routes in parallel
+    const [transitData, railData] = await Promise.all([
+      queryNearbyRoutes(ARCGIS_ENDPOINTS.TRANSIT_ROUTES, lat, lng, distance),
+      queryNearbyRoutes(ARCGIS_ENDPOINTS.RAIL_ROUTES, lat, lng, distance),
+    ]);
+
+    // Transform features to standardized format
+    const transitFeatures = transformTransitFeatures(
+      (transitData.features || []) as ArcGISFeature<ArcGISRouteAttributes>[]
+    );
+    const railFeatures = transformRailFeatures(
+      (railData.features || []) as ArcGISFeature<ArcGISRailAttributes>[]
+    );
+
+    // Merge results
+    const allFeatures = [...transitFeatures, ...railFeatures];
+
+    const geoJsonResponse = {
+      type: 'FeatureCollection' as const,
+      features: allFeatures,
+    };
+
+    return createSuccessResponse(geoJsonResponse);
+  } catch (error) {
+    return handleApiError('query nearby routes', error);
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,7 +46,7 @@ html {
 
 /* Leaflet popup styling for light and dark themes */
 .leaflet-popup-content-wrapper {
-  background: rgba(255, 255, 255, 0.65) !important;
+  background: rgba(255, 255, 255, 0.9) !important;
   backdrop-filter: blur(8px) !important;
   border-radius: 8px !important;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
@@ -55,7 +55,7 @@ html {
 }
 
 .dark .leaflet-popup-content-wrapper {
-  background: rgba(31, 41, 55, 0.65) !important;
+  background: rgba(31, 41, 55, 0.9) !important;
   border: 1px solid rgba(255, 255, 255, 0.1) !important;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4) !important;
   color: #f9fafb !important;
@@ -107,12 +107,12 @@ html {
 }
 
 .leaflet-popup-tip {
-  background: rgba(255, 255, 255, 0.65) !important;
+  background: rgba(255, 255, 255, 0.9) !important;
   box-shadow: none !important;
 }
 
 .dark .leaflet-popup-tip {
-  background: rgba(31, 41, 55, 0.65) !important;
+  background: rgba(31, 41, 55, 0.9) !important;
 }
 
 .leaflet-popup-close-button {
@@ -164,6 +164,16 @@ html {
   }
 }
 
+/* Nearby route badge heartbeat animation */
+@keyframes heartbeat-fade {
+  0%, 100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 0.9;
+  }
+}
+
 /* Target SVG path elements directly for Leaflet compatibility */
 .user-location-marker,
 path.user-location-marker {
@@ -173,4 +183,9 @@ path.user-location-marker {
 .user-location-ring,
 path.user-location-ring {
   animation: pulse-ring 1.8s ease-out infinite !important;
+}
+
+/* Nearby route badge heartbeat animation */
+.nearby-badge-diamond {
+  animation: heartbeat-fade 2.5s ease-in-out infinite !important;
 }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useRef, Fragment } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, Polyline, ZoomControl, CircleMarker, useMap } from 'react-leaflet';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTheme } from 'next-themes';
@@ -8,11 +8,14 @@ import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { isRegionalRailRoute } from '@/constants/routes';
 import { PHILADELPHIA_CENTER, DEFAULT_ROUTES } from '@/constants/map.constants';
+import { NEARBY_ROUTES_CONFIG } from '@/config/api.config';
 import { generateRouteColor } from '@/utils/routeColors';
-import { createRouteIcon } from '@/utils/routeIcons';
+import { createRouteIcon, createNearbyRouteBadge } from '@/utils/routeIcons';
 import { saveRoutesToLocalStorage, resolveRoutes } from '@/utils/routeStorage';
+import { distanceMiles } from '@/utils/geoUtils';
 import type { RouteGeometry } from '@/utils/mapHelpers';
 import { LocationControl } from './LocationControl';
+import { NearbyRoutesControl } from './NearbyRoutesControl';
 import { PermalinkButton } from './PermalinkButton';
 import { ThemeToggle } from './ThemeToggle';
 
@@ -73,6 +76,12 @@ export default function Map() {
   const [isManuallyDragged, setIsManuallyDragged] = useState(false);
   const hasInitialZoomRef = useRef(false);
 
+  // Nearby routes discovery state
+  const [nearbyRoutesEnabled, setNearbyRoutesEnabled] = useState(false);
+  const [nearbyRouteFeatures, setNearbyRouteFeatures] = useState<RouteFeature[]>([]);
+  const lastNearbyQueryLocation = useRef<{ lat: number; lng: number } | null>(null);
+  const lastNearbyQueryTime = useRef<number>(0);
+
   // Determine if we should use dark theme
   const isDark = mounted ? (theme === 'dark' || (theme === 'system' && systemTheme === 'dark')) : false;
 
@@ -98,14 +107,36 @@ export default function Map() {
     }
   }, [mounted]);
 
+  // Load nearby routes preference from localStorage
+  useEffect(() => {
+    if (!mounted) return;
+    const savedLocation = localStorage.getItem('locationSharingEnabled');
+    const savedNearby = localStorage.getItem('nearbyRoutesEnabled');
+    // Only restore if location is also enabled
+    if (savedLocation === 'true' && savedNearby === 'true') {
+      setNearbyRoutesEnabled(true);
+    }
+  }, [mounted]);
+
   // Handle location sharing toggle
   const handleLocationToggle = useCallback(() => {
     const newValue = !locationEnabled;
     setLocationEnabled(newValue);
     localStorage.setItem('locationSharingEnabled', String(newValue));
-    // Reset manual drag state when disabling location
-    if (!newValue) {
+
+    if (newValue) {
+      // When enabling location, also enable nearby routes by default
+      setNearbyRoutesEnabled(true);
+      localStorage.setItem('nearbyRoutesEnabled', 'true');
+    } else {
+      // Reset manual drag state when disabling location
       setIsManuallyDragged(false);
+      // Also disable nearby routes when location is disabled
+      setNearbyRoutesEnabled(false);
+      localStorage.setItem('nearbyRoutesEnabled', 'false');
+      setNearbyRouteFeatures([]);
+      lastNearbyQueryLocation.current = null;
+      lastNearbyQueryTime.current = 0;
     }
   }, [locationEnabled]);
 
@@ -120,6 +151,18 @@ export default function Map() {
   const handleRecenter = useCallback(() => {
     setIsManuallyDragged(false);
   }, []);
+
+  // Handle nearby routes toggle
+  const handleNearbyRoutesToggle = useCallback(() => {
+    const newValue = !nearbyRoutesEnabled;
+    setNearbyRoutesEnabled(newValue);
+    localStorage.setItem('nearbyRoutesEnabled', String(newValue));
+    if (!newValue) {
+      setNearbyRouteFeatures([]);
+      lastNearbyQueryLocation.current = null;
+      lastNearbyQueryTime.current = 0;
+    }
+  }, [nearbyRoutesEnabled]);
 
   // Get routes from URL, local storage, or defaults (in that priority order)
   const getRoutesFromURL = useCallback(() => {
@@ -371,6 +414,55 @@ export default function Map() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [locationEnabled]); // watchId intentionally excluded to prevent infinite loop
 
+  // Fetch nearby routes when location changes
+  useEffect(() => {
+    if (!nearbyRoutesEnabled || !userLocation) {
+      return;
+    }
+
+    const now = Date.now();
+    const timeSinceLastQuery = now - lastNearbyQueryTime.current;
+
+    // Skip if minimum interval hasn't passed
+    if (timeSinceLastQuery < NEARBY_ROUTES_CONFIG.MIN_QUERY_INTERVAL) {
+      return;
+    }
+
+    // Skip if user hasn't moved enough
+    if (lastNearbyQueryLocation.current) {
+      const distanceMoved = distanceMiles(lastNearbyQueryLocation.current, userLocation);
+      if (distanceMoved < NEARBY_ROUTES_CONFIG.REQUERY_THRESHOLD) {
+        return;
+      }
+    }
+
+    // Fetch nearby routes
+    const fetchNearbyRoutes = async () => {
+      try {
+        const response = await fetch(
+          `/api/nearby-routes?lat=${userLocation.lat}&lng=${userLocation.lng}&distance=${NEARBY_ROUTES_CONFIG.QUERY_DISTANCE}`
+        );
+
+        if (!response.ok) {
+          console.warn('Failed to fetch nearby routes:', response.status);
+          return;
+        }
+
+        const data = await response.json();
+
+        if (data.features && Array.isArray(data.features)) {
+          setNearbyRouteFeatures(data.features);
+          lastNearbyQueryLocation.current = userLocation;
+          lastNearbyQueryTime.current = now;
+        }
+      } catch (error) {
+        console.error('Error fetching nearby routes:', error);
+      }
+    };
+
+    fetchNearbyRoutes();
+  }, [nearbyRoutesEnabled, userLocation]);
+
   // Inner component to detect map drag events
   function DragDetector({ onDragStart }: { onDragStart: () => void }) {
     const map = useMap();
@@ -447,7 +539,110 @@ export default function Map() {
           maxZoom={20}
         />
         <ZoomControl position="bottomright" />
-        
+
+        {/* Nearby routes (rendered first so they appear underneath selected routes) */}
+        {nearbyRouteFeatures
+          .filter(feature => !selectedRoutes.includes(feature.properties.LineAbbr))
+          .map((feature, index) => {
+            const route = feature.properties.LineAbbr;
+            let coordinateSets: [number, number][][] = [];
+
+            if (feature.geometry.type === 'LineString') {
+              const coords = feature.geometry.coordinates as [number, number][];
+              coordinateSets = [coords.map(coord =>
+                [coord[1], coord[0]] as [number, number]
+              )];
+            } else if (feature.geometry.type === 'MultiLineString') {
+              const coords = feature.geometry.coordinates as [number, number][][];
+              coordinateSets = coords.map(lineString =>
+                lineString.map(coord => [coord[1], coord[0]] as [number, number])
+              );
+            }
+
+            // Find point on route closest to user's location for badge placement
+            let badgePosition: [number, number] | null = null;
+            if (userLocation && coordinateSets.length > 0) {
+              let minDistance = Infinity;
+              coordinateSets.forEach(segment => {
+                segment.forEach(coord => {
+                  const distance = distanceMiles(
+                    { lat: coord[0], lng: coord[1] },
+                    userLocation
+                  );
+                  if (distance < minDistance) {
+                    minDistance = distance;
+                    badgePosition = coord;
+                  }
+                });
+              });
+            }
+
+            return (
+              <Fragment key={`nearby-route-group-${route}-${index}`}>
+                {/* Polylines */}
+                {coordinateSets.map((coordinates, segmentIndex) => (
+                  <Polyline
+                    key={`nearby-route-${route}-${index}-${segmentIndex}`}
+                    positions={coordinates}
+                    pathOptions={{
+                      color: isDark ? '#888888' : '#666666',
+                      weight: 3,
+                      opacity: isDark ? 0.3 : 0.4,
+                      dashArray: '8, 4',
+                    }}
+                  >
+                    <Popup>
+                      <div style={{ padding: '8px', minWidth: '150px' }}>
+                        <h3 style={{ fontWeight: 'bold', fontSize: '14px', marginBottom: '8px' }}>
+                          {isRegionalRailRoute(route)
+                            ? `Rail ${route}`
+                            : route.startsWith('T')
+                            ? `Trolley ${route}`
+                            : `Route ${route}`}
+                        </h3>
+                        <button
+                          onClick={() => addRoute(route)}
+                          className="w-full px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white text-sm rounded"
+                          disabled={selectedRoutes.length >= 10}
+                        >
+                          Add to my routes
+                        </button>
+                      </div>
+                    </Popup>
+                  </Polyline>
+                ))}
+
+                {/* Static badge marker - diamond shaped, positioned closest to user */}
+                {badgePosition && (
+                  <Marker
+                    key={`nearby-badge-${route}-${index}`}
+                    position={badgePosition}
+                    icon={createNearbyRouteBadge(route, isDark)}
+                  >
+                    <Popup>
+                      <div style={{ padding: '8px', minWidth: '150px' }}>
+                        <h3 style={{ fontWeight: 'bold', fontSize: '14px', marginBottom: '8px' }}>
+                          {isRegionalRailRoute(route)
+                            ? `Rail ${route}`
+                            : route.startsWith('T')
+                            ? `Trolley ${route}`
+                            : `Route ${route}`}
+                        </h3>
+                        <button
+                          onClick={() => addRoute(route)}
+                          className="w-full px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white text-sm rounded"
+                          disabled={selectedRoutes.length >= 10}
+                        >
+                          Add to my routes
+                        </button>
+                      </div>
+                    </Popup>
+                  </Marker>
+                )}
+              </Fragment>
+            );
+          }).flat()}
+
         {/* Official SEPTA route paths */}
         {routeGeometry.map((feature, index) => {
           const route = feature.properties.LineAbbr;
@@ -718,6 +913,14 @@ export default function Map() {
           hasError={!!locationError}
           showRecenter={isManuallyDragged}
           onRecenter={handleRecenter}
+        />
+
+        {/* Nearby routes control */}
+        <NearbyRoutesControl
+          enabled={nearbyRoutesEnabled}
+          onToggle={handleNearbyRoutesToggle}
+          disabled={!locationEnabled}
+          nearbyCount={nearbyRouteFeatures.filter(f => !selectedRoutes.includes(f.properties.LineAbbr)).length}
         />
       </div>
     </div>

--- a/src/components/NearbyRoutesControl.tsx
+++ b/src/components/NearbyRoutesControl.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface NearbyRoutesControlProps {
+  enabled: boolean;
+  onToggle: () => void;
+  disabled: boolean;
+  nearbyCount: number;
+}
+
+export function NearbyRoutesControl({ enabled, onToggle, disabled, nearbyCount }: NearbyRoutesControlProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <div
+        className="p-2 rounded-lg bg-white/65 dark:bg-gray-800/65 shadow-lg backdrop-blur-sm"
+        suppressHydrationWarning={true}
+      >
+        <div className="w-32 h-8" />
+      </div>
+    );
+  }
+
+  const title = disabled
+    ? 'Enable location first'
+    : enabled
+    ? 'Hide nearby routes'
+    : 'Show nearby routes';
+
+  return (
+    <button
+      onClick={onToggle}
+      disabled={disabled}
+      title={title}
+      className={`p-2 rounded-lg shadow-lg backdrop-blur-sm transition-colors duration-200 flex items-center space-x-2 ${
+        disabled
+          ? 'bg-gray-100/65 dark:bg-gray-700/65 cursor-not-allowed opacity-60'
+          : 'bg-white/65 dark:bg-gray-800/65 hover:bg-white/80 dark:hover:bg-gray-700/80'
+      }`}
+    >
+      <input
+        type="checkbox"
+        checked={enabled}
+        onChange={() => {}} // Handled by button onClick
+        disabled={disabled}
+        className="w-4 h-4 accent-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        aria-label="Toggle nearby routes"
+      />
+      <span className="text-sm font-medium text-gray-900 dark:text-white whitespace-nowrap">
+        🔍 Nearby ({nearbyCount})
+      </span>
+    </button>
+  );
+}

--- a/src/config/api.config.ts
+++ b/src/config/api.config.ts
@@ -57,3 +57,17 @@ export const POLLING_INTERVALS = {
   /** How often to check location (if enabled) */
   LOCATION_UPDATES: 1000, // 1 second
 } as const;
+
+/**
+ * Nearby routes discovery settings
+ */
+export const NEARBY_ROUTES_CONFIG = {
+  /** Search radius for nearby routes (in miles) */
+  QUERY_DISTANCE: 0.25,
+
+  /** Minimum user movement to trigger re-query (in miles) */
+  REQUERY_THRESHOLD: 0.1,
+
+  /** Minimum time between queries (in milliseconds) */
+  MIN_QUERY_INTERVAL: 10000, // 10 seconds
+} as const;

--- a/src/utils/geoUtils.test.ts
+++ b/src/utils/geoUtils.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { distanceMiles } from './geoUtils';
+
+describe('distanceMiles', () => {
+  it('calculates distance between Philadelphia City Hall and Liberty Bell (known ~0.8 miles)', () => {
+    const cityHall = { lat: 39.9526, lng: -75.1652 };
+    const libertyBell = { lat: 39.9496, lng: -75.1503 };
+    const distance = distanceMiles(cityHall, libertyBell);
+
+    // Should be approximately 0.7-0.9 miles
+    expect(distance).toBeGreaterThan(0.7);
+    expect(distance).toBeLessThan(0.9);
+  });
+
+  it('returns 0 for identical points', () => {
+    const point = { lat: 39.9526, lng: -75.1652 };
+    const distance = distanceMiles(point, point);
+
+    expect(distance).toBe(0);
+  });
+
+  it('calculates distance between Philadelphia and New York (known ~80 miles)', () => {
+    const philadelphia = { lat: 39.9526, lng: -75.1652 };
+    const newYork = { lat: 40.7128, lng: -74.006 };
+    const distance = distanceMiles(philadelphia, newYork);
+
+    // Should be approximately 80-90 miles
+    expect(distance).toBeGreaterThan(75);
+    expect(distance).toBeLessThan(95);
+  });
+
+  it('calculates small distances accurately (within 0.1 miles threshold)', () => {
+    const start = { lat: 39.9526, lng: -75.1652 };
+    // Point approximately 0.06 miles east
+    const nearby = { lat: 39.9526, lng: -75.1640 };
+    const distance = distanceMiles(start, nearby);
+
+    expect(distance).toBeGreaterThan(0.05);
+    expect(distance).toBeLessThan(0.07);
+  });
+
+  it('handles negative longitude correctly', () => {
+    const point1 = { lat: 39.9526, lng: -75.1652 };
+    const point2 = { lat: 39.9500, lng: -75.1600 };
+    const distance = distanceMiles(point1, point2);
+
+    expect(distance).toBeGreaterThan(0);
+    expect(distance).toBeLessThan(1);
+  });
+
+  it('is commutative (distance A to B equals B to A)', () => {
+    const pointA = { lat: 39.9526, lng: -75.1652 };
+    const pointB = { lat: 39.9496, lng: -75.1503 };
+
+    const distanceAB = distanceMiles(pointA, pointB);
+    const distanceBA = distanceMiles(pointB, pointA);
+
+    expect(distanceAB).toBeCloseTo(distanceBA, 10);
+  });
+
+  it('handles equator crossing (if needed for future expansion)', () => {
+    const northHemisphere = { lat: 1, lng: 0 };
+    const southHemisphere = { lat: -1, lng: 0 };
+    const distance = distanceMiles(northHemisphere, southHemisphere);
+
+    // Should be approximately 138 miles (2 degrees of latitude)
+    expect(distance).toBeGreaterThan(130);
+    expect(distance).toBeLessThan(145);
+  });
+});

--- a/src/utils/geoUtils.ts
+++ b/src/utils/geoUtils.ts
@@ -1,0 +1,43 @@
+/**
+ * Geographic utility functions for location-based calculations
+ */
+
+interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+/**
+ * Calculate the great-circle distance between two points using the Haversine formula
+ *
+ * @param a - First point {lat, lng}
+ * @param b - Second point {lat, lng}
+ * @returns Distance in miles
+ *
+ * @example
+ * ```ts
+ * const distance = distanceMiles(
+ *   { lat: 39.9526, lng: -75.1652 },
+ *   { lat: 39.9500, lng: -75.1600 }
+ * );
+ * console.log(`Distance: ${distance.toFixed(2)} miles`);
+ * ```
+ */
+export function distanceMiles(a: LatLng, b: LatLng): number {
+  const R = 3958.8; // Earth's radius in miles
+  const toRad = (degrees: number) => (degrees * Math.PI) / 180;
+
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+
+  const h =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.sin(dLng / 2) * Math.sin(dLng / 2) * Math.cos(lat1) * Math.cos(lat2);
+
+  const c = 2 * Math.asin(Math.sqrt(h));
+
+  return R * c;
+}

--- a/src/utils/routeIcons.ts
+++ b/src/utils/routeIcons.ts
@@ -37,6 +37,11 @@ const ICON_SIZES = {
     charWidth: 8,
     padding: 12,
   },
+  /** Size for nearby route diamond badges */
+  NEARBY_BADGE: {
+    size: 24,
+    fontSize: '9px',
+  },
 } as const;
 
 /**
@@ -139,5 +144,69 @@ export function createRouteIcon(route: string): L.DivIcon {
     iconSize,
     iconAnchor,
     popupAnchor,
+  });
+}
+
+/**
+ * Creates a diamond-shaped badge icon for nearby routes.
+ *
+ * Visual characteristics:
+ * - Diamond shape (rotated square) with dark greyscale background
+ * - Small route number/label in white text
+ * - Semi-transparent with subtle shadow
+ * - Visually distinct from active vehicle markers
+ *
+ * @param route - Route number or name (e.g., "17", "T101", "Airport Line")
+ * @param isDark - Whether dark theme is active
+ * @returns Leaflet DivIcon with diamond-shaped styling
+ *
+ * @example
+ * ```ts
+ * const icon = createNearbyRouteBadge("17", false);
+ * L.marker([lat, lng], { icon }).addTo(map);
+ * ```
+ */
+export function createNearbyRouteBadge(route: string, isDark: boolean): L.DivIcon {
+  const size = ICON_SIZES.NEARBY_BADGE.size;
+  const fontSize = ICON_SIZES.NEARBY_BADGE.fontSize;
+
+  // Dark greyscale color - darker for light theme, lighter for dark theme
+  const bgColor = isDark ? '#888888' : '#555555';
+
+  // Truncate long route names for display
+  let displayText = route;
+  if (displayText.length > 6) {
+    displayText = displayText.substring(0, 5) + '…';
+  }
+
+  return L.divIcon({
+    html: `
+      <div class="nearby-badge-diamond" style="
+        width: ${size}px;
+        height: ${size}px;
+        background-color: ${bgColor};
+        transform: rotate(45deg);
+        border: 1.5px solid rgba(255,255,255,0.4);
+        box-shadow: 0 1px 4px rgba(0,0,0,0.3);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      ">
+        <div style="
+          transform: rotate(-45deg);
+          font-family: Arial, sans-serif;
+          font-size: ${fontSize};
+          font-weight: bold;
+          color: white;
+          text-align: center;
+          line-height: 1;
+          text-shadow: 1px 1px 1px rgba(0,0,0,0.8);
+        ">${displayText}</div>
+      </div>
+    `,
+    className: '',
+    iconSize: [size, size],
+    iconAnchor: [size / 2, size / 2],
+    popupAnchor: [0, -14],
   });
 }


### PR DESCRIPTION
Enables users to discover SEPTA routes within 0.25 miles of their location using ArcGIS spatial queries. Routes appear as greyscale dashed polylines with animated diamond badges positioned at the closest point to the user.

New components:
- NearbyRoutesControl: Toggle checkbox for enabling/disabling nearby routes discovery
- geoUtils: Haversine distance calculation for proximity detection (7 unit tests)
- /api/nearby-routes: Spatial query endpoint for bus/trolley and regional rail routes

Key features:
- Auto-enables with location tracking for immediate discovery
- Diamond-shaped badges with subtle heartbeat fade animation
- Smart positioning: badges appear at point closest to user's location
- Intelligent re-querying: only triggers after 0.1 mile movement or 10 second interval
- One-tap route addition via popup on polylines and badges
- Dark greyscale styling (matching dashed polylines) distinct from vehicle markers
- 90% opacity popups for better readability

Technical details:
- Server-side spatial queries using ArcGIS point+buffer (efficient, no client-side overhead)
- Filters already-selected routes from nearby display
- Persists enabled state to localStorage
- Cascade disable: location off -> nearby routes off
- Returns merged GeoJSON from both transit and rail endpoints