### PR TITLE
Fix route segment opacity stacking

### DIFF
--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -582,38 +582,17 @@ export default function Map() {
 
             return (
               <Fragment key={`nearby-route-group-${route}-${index}`}>
-                {/* Polylines */}
-                {coordinateSets.map((coordinates, segmentIndex) => (
-                  <Polyline
-                    key={`nearby-route-${route}-${index}-${segmentIndex}`}
-                    positions={coordinates}
-                    pathOptions={{
-                      color: isDark ? '#888888' : '#666666',
-                      weight: 3,
-                      opacity: isDark ? 0.3 : 0.4,
-                      dashArray: '8, 4',
-                    }}
-                  >
-                    <Popup>
-                      <div style={{ padding: '8px', minWidth: '150px' }}>
-                        <h3 style={{ fontWeight: 'bold', fontSize: '14px', marginBottom: '8px' }}>
-                          {isRegionalRailRoute(route)
-                            ? `Rail ${route}`
-                            : route.startsWith('T')
-                            ? `Trolley ${route}`
-                            : `Route ${route}`}
-                        </h3>
-                        <button
-                          onClick={() => addRoute(route)}
-                          className="w-full px-2 py-1 bg-blue-500 hover:bg-blue-600 text-white text-sm rounded"
-                          disabled={selectedRoutes.length >= 10}
-                        >
-                          Add to my routes
-                        </button>
-                      </div>
-                    </Popup>
-                  </Polyline>
-                ))}
+                {/* Single Polyline with all segments — one SVG path element avoids opacity stacking */}
+                <Polyline
+                  key={`nearby-route-${route}-${index}`}
+                  positions={coordinateSets}
+                  pathOptions={{
+                    color: isDark ? '#888888' : '#666666',
+                    weight: 3,
+                    opacity: isDark ? 0.3 : 0.4,
+                    dashArray: '8, 4',
+                  }}
+                />
 
                 {/* Static badge marker - diamond shaped, positioned closest to user */}
                 {badgePosition && (
@@ -646,30 +625,34 @@ export default function Map() {
             );
           }).flat()}
 
-        {/* Official SEPTA route paths */}
-        {routeGeometry.map((feature, index) => {
-          const route = feature.properties.LineAbbr;
+        {/* Official SEPTA route paths — one Polyline (one SVG path) per route to avoid opacity stacking */}
+        {(() => {
+          // Group all coordinate sets by route so every segment for a route
+          // lands in a single SVG <path> element; opacity then applies to the
+          // whole path instead of compounding where individual segments overlap.
+          const routeCoords: Record<string, [number, number][][]> = {};
 
-          // Convert GeoJSON coordinates to Leaflet format
-          // Keep MultiLineString segments separate to avoid connecting disconnected segments
-          let coordinateSets: [number, number][][] = [];
+          routeGeometry.forEach(feature => {
+            const route = feature.properties.LineAbbr;
+            if (!routeCoords[route]) routeCoords[route] = [];
 
-          if (feature.geometry.type === 'LineString') {
-            const coords = feature.geometry.coordinates as [number, number][];
-            coordinateSets = [coords.map(coord =>
-              [coord[1], coord[0]] as [number, number]
-            )];
-          } else if (feature.geometry.type === 'MultiLineString') {
-            const coords = feature.geometry.coordinates as [number, number][][];
-            coordinateSets = coords.map(lineString =>
-              lineString.map(coord => [coord[1], coord[0]] as [number, number])
-            );
-          }
+            if (feature.geometry.type === 'LineString') {
+              const coords = (feature.geometry.coordinates as [number, number][]).map(
+                coord => [coord[1], coord[0]] as [number, number]
+              );
+              routeCoords[route].push(coords);
+            } else if (feature.geometry.type === 'MultiLineString') {
+              (feature.geometry.coordinates as [number, number][][]).forEach(lineString => {
+                const coords = lineString.map(coord => [coord[1], coord[0]] as [number, number]);
+                routeCoords[route].push(coords);
+              });
+            }
+          });
 
-          return coordinateSets.map((coordinates, segmentIndex) => (
+          return Object.entries(routeCoords).map(([route, allCoords]) => (
             <Polyline
-              key={`route-${route}-${index}-${segmentIndex}`}
-              positions={coordinates}
+              key={`route-${route}`}
+              positions={allCoords}
               pathOptions={{
                 color: generateRouteColor(route),
                 weight: 4,
@@ -677,7 +660,7 @@ export default function Map() {
               }}
             />
           ));
-        }).flat()}
+        })()}
         
         {vehicles.map((vehicle) => (
           <Marker

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -14,6 +14,7 @@ import { createRouteIcon, createNearbyRouteBadge } from '@/utils/routeIcons';
 import { saveRoutesToLocalStorage, resolveRoutes } from '@/utils/routeStorage';
 import { distanceMiles } from '@/utils/geoUtils';
 import type { RouteGeometry } from '@/utils/mapHelpers';
+import { chaikinSmooth } from '@/utils/mapHelpers';
 import { LocationControl } from './LocationControl';
 import { NearbyRoutesControl } from './NearbyRoutesControl';
 import { PermalinkButton } from './PermalinkButton';
@@ -552,13 +553,13 @@ export default function Map() {
 
             if (feature.geometry.type === 'LineString') {
               const coords = feature.geometry.coordinates as [number, number][];
-              coordinateSets = [coords.map(coord =>
+              coordinateSets = [chaikinSmooth(coords.map(coord =>
                 [coord[1], coord[0]] as [number, number]
-              )];
+              ))];
             } else if (feature.geometry.type === 'MultiLineString') {
               const coords = feature.geometry.coordinates as [number, number][][];
               coordinateSets = coords.map(lineString =>
-                lineString.map(coord => [coord[1], coord[0]] as [number, number])
+                chaikinSmooth(lineString.map(coord => [coord[1], coord[0]] as [number, number]))
               );
             }
 
@@ -637,13 +638,13 @@ export default function Map() {
             if (!routeCoords[route]) routeCoords[route] = [];
 
             if (feature.geometry.type === 'LineString') {
-              const coords = (feature.geometry.coordinates as [number, number][]).map(
+              const coords = chaikinSmooth((feature.geometry.coordinates as [number, number][]).map(
                 coord => [coord[1], coord[0]] as [number, number]
-              );
+              ));
               routeCoords[route].push(coords);
             } else if (feature.geometry.type === 'MultiLineString') {
               (feature.geometry.coordinates as [number, number][][]).forEach(lineString => {
-                const coords = lineString.map(coord => [coord[1], coord[0]] as [number, number]);
+                const coords = chaikinSmooth(lineString.map(coord => [coord[1], coord[0]] as [number, number]));
                 routeCoords[route].push(coords);
               });
             }

--- a/src/utils/mapHelpers.ts
+++ b/src/utils/mapHelpers.ts
@@ -61,3 +61,38 @@ export function convertGeoJSONToLeaflet(
 export function formatRouteForURL(route: string): string {
   return encodeURIComponent(route);
 }
+
+/**
+ * Smooths a polyline using Chaikin's corner-cutting algorithm.
+ *
+ * Each iteration replaces every segment with two shorter segments whose
+ * endpoints sit at the 25% and 75% positions of the original segment.
+ * The first and last points are kept fixed so the line endpoints don't move.
+ *
+ * Cutting at 25%/75% (rather than 50%/50%) preserves sharper corners, making
+ * it well-suited for transit routes where turns matter but minor bumps should
+ * be ironed out.
+ *
+ * @param coords     - Coordinate array in [lat, lng] format
+ * @param iterations - Number of subdivision passes (default 2)
+ */
+export function chaikinSmooth(
+  coords: [number, number][],
+  iterations = 3,
+): [number, number][] {
+  if (coords.length < 3) return coords;
+
+  let pts = coords;
+  for (let iter = 0; iter < iterations; iter++) {
+    const next: [number, number][] = [pts[0]];
+    for (let i = 0; i < pts.length - 1; i++) {
+      const [lat0, lng0] = pts[i];
+      const [lat1, lng1] = pts[i + 1];
+      next.push([0.75 * lat0 + 0.25 * lat1, 0.75 * lng0 + 0.25 * lng1]);
+      next.push([0.25 * lat0 + 0.75 * lat1, 0.25 * lng0 + 0.75 * lng1]);
+    }
+    next.push(pts[pts.length - 1]);
+    pts = next;
+  }
+  return pts;
+}


### PR DESCRIPTION
Previously each MultiLineString segment was its own <Polyline> (SVG <path>), causing stroke-opacity to compound wherever segments overlapped. Now all coordinate sets for a route are passed as nested arrays to one <Polyline>, so Leaflet emits a single <path> element per route whose opacity applies uniformly across all sub-paths.